### PR TITLE
Add proper image support.

### DIFF
--- a/components/notion.tsx
+++ b/components/notion.tsx
@@ -283,33 +283,40 @@ export const BlockRenderer: React.FC<BlockRenderer> = (props) => {
         </li>
       );
     case "image":
-      console.log(
-        block.value.format.block_aspect_ratio * block.value.format.block_width
-      );
-      const height =
-        block.value.format.block_aspect_ratio * block.value.format.block_width;
+      console.log(block.value);
       return (
-        <div
-          className="w-full"
-          style={{
-            paddingBottom: `${block.value.format.block_aspect_ratio * 100}%`,
-            position: "relative",
-          }}
-        >
-          <LazyLoad
-            height={
-              block.value.format.block_aspect_ratio *
-              block.value.format.block_width
-            }
-            once
+        <div className="flex flex-col flex-wrap content-center">
+          <div
+            className="w-full"
+            style={{
+              paddingBottom: `${
+                block.value.format.block_aspect_ratio *
+                block.value.format.block_width
+              }px`,
+              maxWidth: `${block.value.format.block_width}px`,
+              position: "relative",
+            }}
           >
-            <img
-              src={`https://notion.so/image/${encodeURIComponent(
-                block.value.properties.source[0][0]
-              )}`}
-              className="w-full h-auto absolute"
-            />
-          </LazyLoad>
+            <LazyLoad
+              height={
+                block.value.format.block_aspect_ratio *
+                block.value.format.block_width
+              }
+              once
+            >
+              <img
+                src={`https://notion.so/image/${encodeURIComponent(
+                  block.value.properties.source[0][0]
+                )}`}
+                className="w-full h-auto absolute"
+              />
+            </LazyLoad>
+          </div>
+          {block.value.properties.caption && (
+            <p className="text-gray-600 text-sm pt-3">
+              {block.value.properties.caption[0][0]}
+            </p>
+          )}
         </div>
       );
     default:

--- a/components/notion.tsx
+++ b/components/notion.tsx
@@ -20,8 +20,10 @@ import {
   DecorationType,
   ColorType,
   BaseTextValueType,
+  ImageValueType,
 } from "../types/notion";
 import Link from "next/link";
+import LazyLoad from "react-lazyload";
 
 interface NotionProps {
   blockMap: LoadPageChunkData["recordMap"]["block"];
@@ -281,12 +283,34 @@ export const BlockRenderer: React.FC<BlockRenderer> = (props) => {
         </li>
       );
     case "image":
+      console.log(
+        block.value.format.block_aspect_ratio * block.value.format.block_width
+      );
+      const height =
+        block.value.format.block_aspect_ratio * block.value.format.block_width;
       return (
-        <img
-          src={`https://notion.so/image/${encodeURIComponent(
-            block.value.properties.source[0][0]
-          )}`}
-        />
+        <div
+          className="w-full"
+          style={{
+            paddingBottom: `${block.value.format.block_aspect_ratio * 100}%`,
+            position: "relative",
+          }}
+        >
+          <LazyLoad
+            height={
+              block.value.format.block_aspect_ratio *
+              block.value.format.block_width
+            }
+            once
+          >
+            <img
+              src={`https://notion.so/image/${encodeURIComponent(
+                block.value.properties.source[0][0]
+              )}`}
+              className="w-full h-auto absolute"
+            />
+          </LazyLoad>
+        </div>
       );
     default:
       return <div />;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1311,6 +1311,15 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-lazyload": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@types/react-lazyload/-/react-lazyload-2.6.0.tgz",
+      "integrity": "sha512-VAv6i5RA3O82Q8yuugTXsmGecFOf5GILeILeUdLUs+8PQW1Zg+bety3BfT6gXHdl/wb3PZujlM9rbRd3xab9Vw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -4969,6 +4978,11 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+    },
+    "react-lazyload": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-2.6.7.tgz",
+      "integrity": "sha512-IauJMTOuO73egkBQ/brm0uVMMyxo/2LWCnnzjh7FlvxRMy4P1D5ZjZX9UBMCKRJUqJD441uT+n0hEXlfcjcm8g=="
     },
     "readable-stream": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "prismic-javascript": "^2.7.1",
     "prismic-reactjs": "^1.3.0",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-lazyload": "^2.6.7"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^2.1.2",
     "@types/node": "^13.11.1",
     "@types/react": "^16.9.34",
+    "@types/react-lazyload": "^2.6.0",
     "postcss-preset-env": "^6.7.0",
     "tailwindcss": "^1.2.0",
     "typescript": "^3.8.3"

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -152,7 +152,7 @@ interface ColumnValueType extends BaseValueType {
   };
 }
 
-interface ImageValueType extends BaseValueType {
+export interface ImageValueType extends BaseValueType {
   type: "image";
   properties: {
     source: string[][];

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -156,6 +156,7 @@ export interface ImageValueType extends BaseValueType {
   type: "image";
   properties: {
     source: string[][];
+    caption?: string[][];
   };
   format: {
     block_width: number;


### PR DESCRIPTION
This pull request adds proper image support. Images are now lazily loaded (sadly no placeholder, haven't figured that out yet), have their width set based on how they're resized in Notion, have captions, and don't reflow on load.